### PR TITLE
only retrieve required latest records from historical stock data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Project documentation: https://model.calvin.sg
 The Stock History Analysis project aims to determine the preferred portfolio composition from constituents within the S&P 500 index. This is achieved by analyzing historical stock data using various technical analysis models. The project is currently in its initial iteration and is a work in progress.
 
 ## Objectives
-The primary objective of this iteration is to:
 - Retrieve and clean historical stock data for analysis.
 - Calculate key financial metrics that will serve as inputs for technical analysis models.
 - Store historical stock price data with a suitable schema in Google Firestore document database.
@@ -33,6 +32,14 @@ The key implementation and rationale of the financial-modelling project are:
 - **Firestore document database schema**: Each ticker symbols is stored in a separate Firestore collection. Each collection contains documents of stock price data, with ISO 8601 date string as document id and fields storing stock price data.
 - **Data Processing**: The retrieved data is cleaned and processed to calculate various metrics like closing price, percentage change, holding period yield, holding period return, and portfolio value assuming an initial investment of $1000.
 - **Main Execution**: The main block of the notebook orchestrates the reading of ticker symbols and the retrieval of stock data for each symbol. The results are then appended to a list and printed in JSON format.
+
+## CI/CD Overview
+This project retrieves, cleans, and analyzes historical stock data. The project adopts the following CI/CD features to ensure code and documentation quality and reliability:
+
+- **Static code analysis with Qodana by JetBrains**: This tool checks and improves the code that performs the data retrieval, processing, and analysis of stock data. This includes suggestions to improve upon code quality, security, and duplication issues. The project follows strict type annotations and PEP 8 coding style conventions.
+- **Project and source code documentation with Sphinx and numpy style docstrings**: This documentation explains the purpose, logic, and implementation of data handling and analysis in various modules. It uses Sphinx to generate HTML documentation from docstrings in a standard format for scientific and numerical projects.
+- **Sphinx build hosting with GitHub Pages and Cloudflare CDN**: This feature makes the documentation accessible and available for users and developers who want to learn more about this project and its results. It hosts static websites from this GitHub repository and uses a custom domain: https://model.calvin.sg to deliver web content faster and more securely.
+- **Workflow automation and configuration management with GitHub Actions and Infrastructure as Code**: This feature manages and automates the CI/CD workflows and ensures that the code and documentation are always in sync with the latest changes. It uses GitHub Actions to run the static code analysis tool and deploy the Sphinx build onto GitHub Pages.
 
 ## Getting started
 To use this project, follow these steps:

--- a/config/app_config.py
+++ b/config/app_config.py
@@ -1,7 +1,12 @@
 from typing import Literal, cast
+
 from decouple import config
 
-DATA_PROVIDER: Literal['fmp', 'intrinio', 'polygon', 'tiingo', 'yfinance'] \
-    = cast(Literal['fmp', 'intrinio', 'polygon', 'tiingo', 'yfinance'], config('DATA_PROVIDER', default='yfinance'))
+from src.main.data_models.stock_price_data import ProviderEnum
+
+DATA_PROVIDER: Literal[
+    ProviderEnum.FMP, ProviderEnum.INTRINIO, ProviderEnum.POLYGON, ProviderEnum.TIINGO, ProviderEnum.YFINANCE] = cast(
+    Literal[ProviderEnum.FMP, ProviderEnum.INTRINIO, ProviderEnum.POLYGON, ProviderEnum.TIINGO, ProviderEnum.YFINANCE],
+    config('DATA_PROVIDER', default='yfinance'))
 TICKER_SYMBOLS_LIST: str = str(config('TICKER_SYMBOLS_LIST', default="../../data/test.csv"))
 FIRESTORE_SERVICE_ACCOUNT: str = str(config('FIRESTORE_SERVICE_ACCOUNT', default=None))

--- a/config/app_config.py
+++ b/config/app_config.py
@@ -4,9 +4,11 @@ from decouple import config
 
 from src.main.data_models.stock_price_data import ProviderEnum
 
-DATA_PROVIDER: Literal[
-    ProviderEnum.FMP, ProviderEnum.INTRINIO, ProviderEnum.POLYGON, ProviderEnum.TIINGO, ProviderEnum.YFINANCE] = cast(
-    Literal[ProviderEnum.FMP, ProviderEnum.INTRINIO, ProviderEnum.POLYGON, ProviderEnum.TIINGO, ProviderEnum.YFINANCE],
+DATA_PROVIDER: Literal[ProviderEnum.FMP: ProviderEnum, ProviderEnum.INTRINIO: ProviderEnum,
+                       ProviderEnum.POLYGON: ProviderEnum, ProviderEnum.TIINGO: ProviderEnum,
+                       ProviderEnum.YFINANCE: ProviderEnum] = cast(
+    Literal[ProviderEnum.FMP: ProviderEnum, ProviderEnum.INTRINIO: ProviderEnum, ProviderEnum.POLYGON: ProviderEnum,
+            ProviderEnum.TIINGO: ProviderEnum, ProviderEnum.YFINANCE: ProviderEnum],
     config('DATA_PROVIDER', default='yfinance'))
 TICKER_SYMBOLS_LIST: str = str(config('TICKER_SYMBOLS_LIST', default="../../data/test.csv"))
 FIRESTORE_SERVICE_ACCOUNT: str = str(config('FIRESTORE_SERVICE_ACCOUNT', default=None))

--- a/config/app_config.py
+++ b/config/app_config.py
@@ -2,13 +2,6 @@ from typing import Literal, cast
 
 from decouple import config
 
-from src.main.data_models.stock_price_data import ProviderEnum
-
-DATA_PROVIDER: Literal[ProviderEnum.FMP: ProviderEnum, ProviderEnum.INTRINIO: ProviderEnum,
-                       ProviderEnum.POLYGON: ProviderEnum, ProviderEnum.TIINGO: ProviderEnum,
-                       ProviderEnum.YFINANCE: ProviderEnum] = cast(
-    Literal[ProviderEnum.FMP: ProviderEnum, ProviderEnum.INTRINIO: ProviderEnum, ProviderEnum.POLYGON: ProviderEnum,
-            ProviderEnum.TIINGO: ProviderEnum, ProviderEnum.YFINANCE: ProviderEnum],
-    config('DATA_PROVIDER', default='yfinance'))
+DATA_PROVIDER: str = config('DATA_PROVIDER', default='yfinance')
 TICKER_SYMBOLS_LIST: str = str(config('TICKER_SYMBOLS_LIST', default="../../data/test.csv"))
 FIRESTORE_SERVICE_ACCOUNT: str = str(config('FIRESTORE_SERVICE_ACCOUNT', default=None))

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,6 +52,16 @@ The key implementation and rationale of the financial-modelling project are:
 - Data Processing: The retrieved data is cleaned and processed to calculate various metrics like closing price, percentage change, holding period yield, holding period return, and portfolio value assuming an initial investment of $1000.
 - Main Execution: The main block of the notebook orchestrates the reading of ticker symbols and the retrieval of stock data for each symbol. The results are then appended to a list and printed in JSON format.
 
+CI/CD Overview
+==============
+
+This project retrieves, cleans, and analyzes historical stock data. The project adopts the following CI/CD features to ensure code and documentation quality and reliability:
+
+- **Static code analysis with Qodana by JetBrains**: This tool checks and improves the code that performs the data retrieval, processing, and analysis of stock data. This includes suggestions to improve upon code quality, security, and duplication issues. The project follows strict type annotations and PEP 8 coding style conventions.
+- **Project and source code documentation with Sphinx and numpy style docstrings**: This documentation explains the purpose, logic, and implementation of data handling and analysis in various modules. It uses Sphinx to generate HTML documentation from docstrings in a standard format for scientific and numerical projects.
+- **Sphinx build hosting with GitHub Pages and Cloudflare CDN**: This feature makes the documentation accessible and available for users and developers who want to learn more about this project and its results. It hosts static websites from this GitHub repository and uses a custom domain: `https://model.calvin.sg` to deliver web content faster and more securely.
+- **Workflow automation and configuration management with GitHub Actions and Infrastructure as Code**: This feature manages and automates the CI/CD workflows and ensures that the code and documentation are always in sync with the latest changes. It uses GitHub Actions to run the static code analysis tool and deploy the Sphinx build onto GitHub Pages.
+
 
 Getting started
 ---------------

--- a/src/main/app.py
+++ b/src/main/app.py
@@ -6,7 +6,7 @@ from src.main.helpers.firestore_update import FirestoreDB, process_stock_data
 if __name__ == "__main__":
     # Read the ticker symbols from the CSV file
     ticker_symbols: list[str] = list(read_ticker_symbols(file_path=TICKER_SYMBOLS_LIST,
-                                                         ticker_column="Symbol"))
+                                                         symbol_column="Symbol"))
     print(ticker_symbols)
 
     # Create a firestore database object

--- a/src/main/app.py
+++ b/src/main/app.py
@@ -1,47 +1,6 @@
-import json
-
-from config.app_config import DATA_PROVIDER, TICKER_SYMBOLS_LIST
+from config.app_config import TICKER_SYMBOLS_LIST
 from src.main.helpers.read_csv import read_ticker_symbols
-from src.main.helpers.firestore_update import FirestoreDB, store_data
-from src.main.data_models.stock_price_data import get_stock_data, StockData
-
-
-def fetch_stock_data(symbols) -> list[StockData]:
-    """
-    Fetch stock data for given symbols.
-
-    Parameters
-    ----------
-    symbols : list
-        list of ticker symbols to fetch data for.
-
-    Returns
-    -------
-    list
-        list of stock data for each ticker symbol.
-    """
-    ticker_list: list[StockData] = []
-    for ticker in symbols:
-        data: StockData = get_stock_data(symbol=ticker, provider=DATA_PROVIDER, start_date="2024-01-01", interval="1d")
-        # Append the data to the stock_ticker_list
-        ticker_list.append(data)
-    return ticker_list
-
-
-def log_stock_data(ticker_list):
-    """
-    Log stock data for given ticker list.
-
-    Parameters
-    ----------
-    ticker_list : list
-        list of stock data to log.
-    """
-    # Log stock_ticker_list as a prettified JSON
-    ticker_list_json = json.dumps(
-        [data.dict() for data in ticker_list], indent=2
-    )
-    print(ticker_list_json)
+from src.main.helpers.firestore_update import FirestoreDB, process_stock_data
 
 
 if __name__ == "__main__":
@@ -50,11 +9,10 @@ if __name__ == "__main__":
                                                          ticker_column="Symbol"))
     print(ticker_symbols)
 
-    stock_ticker_list: list[StockData] = list(fetch_stock_data(symbols=ticker_symbols))
-    log_stock_data(stock_ticker_list)
-
     # Create a firestore database object
     firestore_db = FirestoreDB()
 
-    # Store the data
-    store_data(stock_data_list=stock_ticker_list, firestore_db=firestore_db)
+    # Loop through each ticker symbol
+    for ticker in ticker_symbols:
+        # Process the stock data for the ticker
+        process_stock_data(ticker=ticker, firestore_db=firestore_db)

--- a/src/main/data_models/stock_price_data.py
+++ b/src/main/data_models/stock_price_data.py
@@ -75,8 +75,9 @@ class StockData(BaseModel):
     stock_price_data: list[StockPriceData]
 
 
-def get_stock_data(symbol: str, provider: Literal[
-    ProviderEnum.FMP, ProviderEnum.INTRINIO, ProviderEnum.POLYGON, ProviderEnum.TIINGO, ProviderEnum.YFINANCE],
+def get_stock_data(symbol: str, provider: Literal[ProviderEnum.FMP: ProviderEnum, ProviderEnum.INTRINIO: ProviderEnum,
+                                                  ProviderEnum.POLYGON: ProviderEnum, ProviderEnum.TIINGO: ProviderEnum,
+                                                  ProviderEnum.YFINANCE: ProviderEnum],
                    start_date: str, end_date: str, interval: str) -> StockData:
     """
     Retrieves and processes stock data for a given symbol, provider, start date, and interval.

--- a/src/main/helpers/firestore_init.py
+++ b/src/main/helpers/firestore_init.py
@@ -173,9 +173,9 @@ class FirestoreDB:
         2. Implementation Details
             - The method first gets the ticker collection reference from the firestore database object.
             - Then, it queries the ticker collection for the most recent document by ordering the documents by
-            the date field in descending order and limiting the result to one document.
+              the date field in descending order and limiting the result to one document.
             - Next, it checks if the query result is empty. If yes, it returns None.
-            If no, it gets the first document from the result and extracts the date field from the document.
+              If no, it gets the first document from the result and extracts the date field from the document.
             - Finally, it returns the date as the output.
         """
 

--- a/src/main/helpers/firestore_init.py
+++ b/src/main/helpers/firestore_init.py
@@ -162,7 +162,8 @@ class FirestoreDB:
         Returns
         -------
         Any | None
-            The most recent date of the stock data in ISO format, e.g. "2024-02-18", or None if the ticker collection is empty.
+            The most recent date of the stock data in ISO format, e.g. "2024-02-18",
+            or None if the ticker collection is empty.
 
         Notes
         -----

--- a/src/main/helpers/firestore_update.py
+++ b/src/main/helpers/firestore_update.py
@@ -1,16 +1,17 @@
-from config.app_config import FIRESTORE_SERVICE_ACCOUNT
-from src.main.helpers.firestore_init import firestore_init, FirestoreDB
-from src.main.data_models.stock_price_data import StockData, StockPriceData
+import datetime
+
+from src.main.helpers.firestore_init import FirestoreDB
+from src.main.data_models.stock_price_data import StockData, StockPriceData, fetch_stock_data, log_stock_data
 
 
-def store_data(stock_data_list: list[StockData], firestore_db: FirestoreDB) -> None:
+def store_data(stock_data: StockData, firestore_db: FirestoreDB) -> None:
     """
     Store the stock price data in the firestore database.
 
     Parameters
     ----------
-    stock_data_list: list[StockData]
-        A list of StockData objects containing the ticker and the stock price data.
+    stock_data: StockData
+        Object containing the ticker and the stock price data.
     firestore_db: FirestoreDB
         A FirestoreDB object representing the firestore database.
 
@@ -36,31 +37,81 @@ def store_data(stock_data_list: list[StockData], firestore_db: FirestoreDB) -> N
         - The function checks if the document exists and updates the existing document
           or creates a new document with the stock price data.
     """
-    # Iterate over the stock price list
-    for stock_data in stock_data_list:
-        # Get the ticker and the stock price data
-        ticker: str = stock_data.ticker
-        stock_price_data: list[StockPriceData] = stock_data.stock_price_data
+    # Get the ticker and the stock price data
+    ticker: str = stock_data.ticker
+    stock_price_data: list[StockPriceData] = stock_data.stock_price_data
 
-        # Check if the ticker collection exists
-        # If not, create a new collection
-        collection = firestore_db.get_collection(ticker)
-        if collection is None:
-            collection = firestore_db.create_collection(ticker)
+    # Check if the ticker collection exists
+    # If not, create a new collection
+    collection = firestore_db.get_collection(ticker)
+    if collection is None:
+        collection = firestore_db.create_collection(ticker)
 
-        # Iterate over the stock price data
-        for stock_price in stock_price_data:
-            # Get the date string
-            date: str = stock_price.date
+    # Iterate over the stock price data
+    for stock_price in stock_price_data:
+        # Get the date string
+        date: str = stock_price.date
 
-            # Use the document path to get the date document
-            date_document = firestore_db.document(ticker=ticker, date=date)
-            # Try to get the document snapshot
-            date_document_snapshot = date_document.get()
-            # Check if the document exists
-            if date_document_snapshot.exists:
-                # Update the existing document
-                firestore_db.update_document(date_document, stock_price.to_dict())
-            else:
-                # Create a new document
-                firestore_db.create_document(collection, date, stock_price.to_dict())
+        # Use the document path to get the date document
+        date_document = firestore_db.document(ticker=ticker, date=date)
+        # Try to get the document snapshot
+        date_document_snapshot = date_document.get()
+        # Check if the document exists
+        if date_document_snapshot.exists:
+            # Update the existing document
+            firestore_db.update_document(date_document, stock_price.to_dict())
+        else:
+            # Create a new document
+            firestore_db.create_document(collection, date, stock_price.to_dict())
+
+
+def process_stock_data(ticker: str, firestore_db: FirestoreDB) -> None:
+    """
+    Process the stock data for a given ticker symbol and a firestore database object.
+
+    Parameters
+    ----------
+    ticker : str
+        The stock ticker symbol, e.g. "AAPL" for Apple Inc.
+    firestore_db : FirestoreDB
+        The firestore database object that handles the connection and operations with firestore.
+
+    Returns
+    -------
+    None
+
+    Notes
+    -----
+    1. Rationale
+        This function aims to update the stock data for a given ticker symbol in firestore, used for further analysis
+
+    2. Implementation Details
+        - The function first checks if the ticker collection exists in firestore.
+        - If not, it creates a new collection for the ticker and sets the start date to an arbitrary date.
+        - If yes, it gets the most recent date of the existing data and sets it as the start date.
+        - Then, it sets the end date to the current date and fetches the stock data for the ticker and the date range,
+        using OpenBB external API with yfinance data source.
+        - Next, it logs the stock data using a custom logger function. Finally, it stores the data in firestore using a custom store function.
+    """
+    # Check if the ticker collection exists in firestore
+    collection = firestore_db.get_collection(ticker)
+    if collection is None:
+        # Get the most recent date of the existing data
+        start_date: str = firestore_db.get_most_recent_date(ticker)
+    else:
+        # Create a new collection for the ticker
+        firestore_db.create_collection(ticker)
+        # Set the start date to arbitrary start date
+        start_date: str = "2024-02-01"  # Arbitrary start date
+
+    # Set the end date to the current date
+    end_date: str = datetime.date.today().isoformat()
+
+    # Fetch the stock data for the ticker and the date range
+    stock_data: StockData = fetch_stock_data(symbol=ticker, start_date=start_date, end_date=end_date)
+
+    # Log the stock data
+    log_stock_data(stock_data)
+
+    # Store the data in firestore
+    store_data(stock_data=stock_data, firestore_db=firestore_db)

--- a/src/main/helpers/firestore_update.py
+++ b/src/main/helpers/firestore_update.py
@@ -1,7 +1,7 @@
 import datetime
 
-from src.main.helpers.firestore_init import FirestoreDB
 from src.main.data_models.stock_price_data import StockData, StockPriceData, fetch_stock_data, log_stock_data
+from src.main.helpers.firestore_init import FirestoreDB
 
 
 def store_data(stock_data: StockData, firestore_db: FirestoreDB) -> None:
@@ -38,7 +38,7 @@ def store_data(stock_data: StockData, firestore_db: FirestoreDB) -> None:
           or creates a new document with the stock price data.
     """
     # Get the ticker and the stock price data
-    ticker: str = stock_data.ticker
+    ticker: str = stock_data.symbol
     stock_price_data: list[StockPriceData] = stock_data.stock_price_data
 
     # Check if the ticker collection exists
@@ -85,13 +85,12 @@ def process_stock_data(ticker: str, firestore_db: FirestoreDB) -> None:
     1. Rationale
         This function aims to update the stock data for a given ticker symbol in firestore, used for further analysis
 
-    2. Implementation Details
-        - The function first checks if the ticker collection exists in firestore.
-        - If not, it creates a new collection for the ticker and sets the start date to an arbitrary date.
-        - If yes, it gets the most recent date of the existing data and sets it as the start date.
-        - Then, it sets the end date to the current date and fetches the stock data for the ticker and the date range,
-        using OpenBB external API with yfinance data source.
-        - Next, it logs the stock data using a custom logger function. Finally, it stores the data in firestore using a custom store function.
+    2. Implementation Details - The function first checks if the ticker collection exists in firestore. - If not,
+    it creates a new collection for the ticker and sets the start date to an arbitrary date. - If yes, it gets the
+    most recent date of the existing data and sets it as the start date. - Then, it sets the end date to the current
+    date and fetches the stock data for the ticker and the date range, using OpenBB external API with yfinance data
+    source. - Next, it logs the stock data using a custom logger function. Finally, it stores the data in firestore
+    using a custom store function.
     """
     # Check if the ticker collection exists in firestore
     collection = firestore_db.get_collection(ticker)

--- a/src/main/helpers/read_csv.py
+++ b/src/main/helpers/read_csv.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 
-def read_ticker_symbols(file_path: str, ticker_column: str) -> list[str]:
+def read_ticker_symbols(file_path: str, symbol_column: str) -> list[str]:
     """
     Read ticker symbols from a CSV file.
 
@@ -9,7 +9,7 @@ def read_ticker_symbols(file_path: str, ticker_column: str) -> list[str]:
     ----------
     file_path: str
         The path to the CSV file.
-    ticker_column: str
+    symbol_column: str
         The header of the column containing the ticker symbols.
 
     Returns
@@ -35,6 +35,6 @@ def read_ticker_symbols(file_path: str, ticker_column: str) -> list[str]:
     df: pd.DataFrame = pd.read_csv(str(file_path))
 
     # Extract the ticker symbols
-    ticker_symbols: list[str] = df[ticker_column].tolist()
+    ticker_symbols: list[str] = df[symbol_column].tolist()
 
     return ticker_symbols


### PR DESCRIPTION
If this `ticker` name exists, access existing `ticker` collection, and proceed with the following logic:
1. for this ticker, retrieve the most recent `date` as document id
2. most recent date is defined as start date
3. current date is defined as end date
4. query historical stock price data store using this start and end date to retrieve stock price data to be inserted
5. Existing stock data in firestore is not required to be retrieved again

Tested in local
1. Retrieved ticker list from CSV and printed StockData retrieved from historical stock price data source
<img width="1115" alt="Screenshot 2024-02-19 at 12 43 48 AM" src="https://github.com/calvindotsg/financial-modelling/assets/68703834/05bd944c-6d9c-44ca-830b-cf359415f019">

2. StockData stored in Firestore
<img width="1069" alt="Screenshot 2024-02-19 at 12 44 42 AM" src="https://github.com/calvindotsg/financial-modelling/assets/68703834/879bb431-e46e-4715-8ee6-68d76391d874">